### PR TITLE
send metrics metadata before start test

### DIFF
--- a/src/main/java/com/dynatrace/jmeter/plugins/MintBackendListener.java
+++ b/src/main/java/com/dynatrace/jmeter/plugins/MintBackendListener.java
@@ -16,6 +16,19 @@
 
 package com.dynatrace.jmeter.plugins;
 
+import com.dynatrace.mint.MintDimension;
+import com.dynatrace.mint.MintGauge;
+import com.dynatrace.mint.MintMetricsLine;
+import com.dynatrace.mint.SchemalessMetricSanitizer;
+import org.apache.jmeter.config.Arguments;
+import org.apache.jmeter.samplers.SampleResult;
+import org.apache.jmeter.visualizers.backend.AbstractBackendListenerClient;
+import org.apache.jmeter.visualizers.backend.BackendListenerContext;
+import org.apache.jmeter.visualizers.backend.SamplerMetric;
+import org.apache.jmeter.visualizers.backend.UserMetric;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -30,23 +43,9 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.jmeter.config.Arguments;
-import org.apache.jmeter.samplers.SampleResult;
-import org.apache.jmeter.visualizers.backend.AbstractBackendListenerClient;
-import org.apache.jmeter.visualizers.backend.BackendListenerContext;
-import org.apache.jmeter.visualizers.backend.SamplerMetric;
-import org.apache.jmeter.visualizers.backend.UserMetric;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.dynatrace.mint.MintDimension;
-import com.dynatrace.mint.MintGauge;
-import com.dynatrace.mint.MintMetricsLine;
-import com.dynatrace.mint.SchemalessMetricSanitizer;
-
 public class MintBackendListener extends AbstractBackendListenerClient implements Runnable {
 	private static final Logger log = LoggerFactory.getLogger(MintBackendListener.class);
-	private static final Map<String, String> DEFAULT_ARGS = new HashMap();
+	private static final Map<String, String> DEFAULT_ARGS = new HashMap<>();
 	private static final long SEND_INTERVAL = 60;
 	private ScheduledExecutorService scheduler;
 	private ScheduledFuture<?> timerHandle;
@@ -112,6 +111,7 @@ public class MintBackendListener extends AbstractBackendListenerClient implement
 			try {
 				mintMetricSender.setup(listenerName, dynatraceMetricIngestUrl, dynatraceApiToken);
 				mintMetricSender.checkConnection();
+                mintMetricSender.setupMetrics();
 				log.info("{}: Start MINT metric sender for url {}", listenerName, dynatraceMetricIngestUrl);
 			} catch (Exception ex) {
 				log.info("{}: Start MINT metric sender for url {} failed with {}, setting enabled state to false",

--- a/src/main/java/com/dynatrace/mint/MintMetricsLine.java
+++ b/src/main/java/com/dynatrace/mint/MintMetricsLine.java
@@ -28,7 +28,14 @@ public class MintMetricsLine {
 		this.metricKey = metricKey;
 	}
 
-	public void addDimension(MintDimension dimension) {
+    public MintMetricsLine(String metricKey, String displayName, String unit, String description) {
+        this(metricKey);
+        addDimension(new MintDimension("dt.meta.unit", unit));
+        addDimension(new MintDimension("dt.meta.description", description));
+        addDimension(new MintDimension("dt.meta.displayname", displayName));
+    }
+
+    public void addDimension(MintDimension dimension) {
 		dimensions.add(dimension);
 	}
 
@@ -36,14 +43,14 @@ public class MintMetricsLine {
 		gauges.add(gauge);
 	}
 
-	public String printMessage() {
+	public String printMessage(boolean metadata) {
 		StringBuilder dimensionString = new StringBuilder();
 		StringBuilder gaugeString = new StringBuilder();
 
 		for (MintDimension d : dimensions) {
 			dimensionString.append(d.dimensionKey);
 			dimensionString.append("=");
-			dimensionString.append(d.dimensionValue);
+            dimensionString.append(addQuotes(d.dimensionValue, metadata));
 			dimensionString.append(",");
 		}
 
@@ -59,16 +66,24 @@ public class MintMetricsLine {
 			gaugeString.setLength(gaugeString.length() - 1);
 		}
 
-		long timestampMillis = System.currentTimeMillis();
-		if (dimensionString.length() > 0) {
-			return metricKey + "," + dimensionString + " " + "gauge," + gaugeString + " " + timestampMillis;
-		} else {
-			return metricKey + " " + "gauge," + gaugeString + " " + timestampMillis;
-		}
+        long timestampMillis = System.currentTimeMillis();
+        if (dimensionString.length() > 0) {
+            if (metadata) {
+                return "#" + metricKey + " gauge " + dimensionString;
+            } else {
+                return metricKey + "," + dimensionString + " " + "gauge," + gaugeString + " " + timestampMillis;
+            }
+        } else {
+            return metricKey + " " + "gauge," + gaugeString + " " + timestampMillis;
+        }
 	}
 
-	@Override
+    private String addQuotes(String string, boolean addQuotes) {
+        return addQuotes ? ("\"" + string + "\"") : string;
+    }
+
+    @Override
 	public String toString() {
-		return printMessage();
+		return printMessage(false);
 	}
 }

--- a/src/test/java/com/dynatrace/jmeter/plugins/MintMetricSenderTest.java
+++ b/src/test/java/com/dynatrace/jmeter/plugins/MintMetricSenderTest.java
@@ -1,17 +1,16 @@
 package com.dynatrace.jmeter.plugins;
 
-import static org.junit.Assert.assertEquals;
-
-import java.util.ArrayList;
-import java.util.List;
-
-import org.junit.Before;
-import org.junit.Test;
-
 import com.dynatrace.mint.MintDimension;
 import com.dynatrace.mint.MintGauge;
 import com.dynatrace.mint.MintMetricsLine;
 import com.dynatrace.mint.SchemalessMetricSanitizer;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
 
 public class MintMetricSenderTest {
 	private MintMetricSender mintMetricSender;
@@ -69,7 +68,7 @@ public class MintMetricSenderTest {
 
 		while (messageSize < MintMetricSender.MAX_MESSAGE_SIZE_BYTES) {
 			MintMetricsLine line = createLine("metric-key-" + idx, idx, 100, "dimKey", "dimValue");
-			messageSize += line.printMessage().length();
+			messageSize += line.printMessage(false).length();
 			idx++;
 			lines.add(line);
 		}
@@ -77,6 +76,15 @@ public class MintMetricSenderTest {
 		assertEquals(2, splitMessages.size());
 
 	}
+
+    @Test
+    public void testCreateLineWithMetaData() {
+        MintMetricsLine line = new MintMetricsLine("jmeter.usermetrics.minactivethreads",
+                "JMeter - min active threads", "count", "the minimum number of active threads");
+        String metadataString = line.printMessage(true);
+        assertEquals("#jmeter.usermetrics.minactivethreads gauge dt.meta.unit=\"count\","
+                + "dt.meta.description=\"the minimum number of active threads\",dt.meta.displayname=\"JMeter - min active threads\"", metadataString);
+    }
 
 	private MintMetricsLine createLine(String metricKey, int metricValue, int nrDimensions, String dimensionKeyPrefix,
 			String dimensionValuePrefix) {


### PR DESCRIPTION
We have several loadtest projects and organise them in different Dynatrace environments. For each environment we have to modify the Metric metadata for all 14 JMeter metrics. This PR uses the metadata feature for the ingest protocol: https://www.dynatrace.com/support/help/extend-dynatrace/extend-metrics/reference/metric-ingestion-protocol#metadata

